### PR TITLE
app: Reset letter-spacing for invite-code-entry popover

### DIFF
--- a/aardvark-app/src/style.css
+++ b/aardvark-app/src/style.css
@@ -5,6 +5,11 @@
   font-weight: bold;
 }
 
+/* HACK: the letter-spacing is also applied to the popover */
+.invite-code-entry > popover {
+  letter-spacing: 0px;
+}
+
 .invite-code-entry {
   border-radius: 15px;
   padding: 15px 20px;


### PR DESCRIPTION
GTK applies the letter-spacing for children of the textview used for the entry. Unfortunately properties set for the `text` node of the textview don't get applied.

Closes: https://github.com/p2panda/aardvark/issues/77