### PR TITLE
Open menu and headerbar spacing fixes

### DIFF
--- a/aardvark-app/src/style.css
+++ b/aardvark-app/src/style.css
@@ -31,7 +31,7 @@
 }
 
 .connection-popover list {
- margin: 9px 3px;
+    margin: 3px 3px;
 }
 
 .this-device-pill {
@@ -52,8 +52,8 @@
 }
 
 .open-popover row {
-  border-radius: 6px;
-  margin: 6px;
+  border-radius: 8px;
+  margin: 2px 6px;
 }
 
 .open-popover .open-document {

--- a/aardvark-app/src/window.ui
+++ b/aardvark-app/src/window.ui
@@ -90,7 +90,6 @@
             </child>
             <child type="end">
               <object class="GtkMenuButton" id="connection_button">
-                <property name="margin-end">6</property>
                 <style>
                   <class name="flat"/>
                 </style>


### PR DESCRIPTION
Fixes two minor spacing issues:
- too much spacing between items in the document list
- too much spacing to the right of the users button in the headerbar