### PR TITLE
ui: minor padding fix on user list popover

### DIFF
--- a/reflection-app/src/style.css
+++ b/reflection-app/src/style.css
@@ -25,7 +25,7 @@
 }
 
 .connection-popover > contents {
-  padding: 0px;
+  padding: 9px 0px;
 }
 
 .avatar {


### PR DESCRIPTION
Adds a bit more vertical padding to the popover.

Before:

![Screenshot From 2025-06-12 13-02-43](https://github.com/user-attachments/assets/e4b92c3d-e5cf-4f45-b569-51adc0cacc18)


After:

![image](https://github.com/user-attachments/assets/bec26602-9c9b-43ba-a44d-4ebb6194e0ea)
