### PR TITLE
doc: Use reexported p2panda_core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4338,7 +4338,6 @@ dependencies = [
  "gio",
  "glib",
  "loro",
- "p2panda-core",
  "reflection-node",
  "thiserror 2.0.12",
  "tracing",

--- a/reflection-doc/Cargo.toml
+++ b/reflection-doc/Cargo.toml
@@ -14,6 +14,5 @@ async-channel = "2.3.1"
 glib = "0.20"
 gio = "0.20"
 loro = "1.5"
-p2panda-core = { git = "https://github.com/p2panda/p2panda", rev = "5e3816cc63af30ea5a8f3745e73ada265e700cf9", default-features = false }
 thiserror = "2.0.11"
 tracing = "0.1"

--- a/reflection-doc/src/document.rs
+++ b/reflection-doc/src/document.rs
@@ -7,8 +7,8 @@ use glib::prelude::*;
 use glib::subclass::{Signal, prelude::*};
 use glib::{Properties, clone};
 use loro::{ExportMode, LoroDoc, LoroText, event::Diff};
-use p2panda_core::HashError;
 use reflection_node::document::{DocumentId as DocumentIdNode, SubscribableDocument};
+use reflection_node::p2panda_core;
 use tracing::error;
 
 use crate::authors::Authors;
@@ -20,7 +20,7 @@ use crate::service::Service;
 pub struct DocumentId(pub(crate) DocumentIdNode);
 
 impl FromStr for DocumentId {
-    type Err = HashError;
+    type Err = p2panda_core::HashError;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         Ok(DocumentId(DocumentIdNode::from_str(value)?))

--- a/reflection-doc/src/lib.rs
+++ b/reflection-doc/src/lib.rs
@@ -5,7 +5,8 @@ pub mod documents;
 pub mod service;
 
 pub mod identity {
-    pub use p2panda_core::identity::IdentityError;
+    use reflection_node::p2panda_core;
+    pub use reflection_node::p2panda_core::identity::IdentityError;
     use std::fmt;
 
     #[derive(Clone, Debug, glib::Boxed)]

--- a/reflection-doc/src/service.rs
+++ b/reflection-doc/src/service.rs
@@ -2,7 +2,7 @@ use gio::prelude::FileExt;
 use glib::Properties;
 use glib::object::ObjectExt;
 use glib::subclass::prelude::*;
-use p2panda_core::Hash;
+use reflection_node::p2panda_core::Hash;
 use std::sync::OnceLock;
 use tracing::error;
 

--- a/reflection-node/src/lib.rs
+++ b/reflection-node/src/lib.rs
@@ -7,3 +7,5 @@ mod utils;
 
 pub use document::SubscribableDocument;
 pub use node::Node;
+
+pub use p2panda_core;


### PR DESCRIPTION
Ideally we would need access to p2panda crates in the doc, but reexporting it from node is still an improvement that guarantee the same version between reflection crates.