### PR TITLE
app: Remove old bg css classes from recycled avatars

### DIFF
--- a/reflection-app/src/components/avatar.rs
+++ b/reflection-app/src/components/avatar.rs
@@ -44,6 +44,11 @@ mod imp {
         }
 
         fn set_author(&self, author: Option<Author>) {
+            for css_class in self.obj().css_classes() {
+                if css_class.starts_with("bg-") {
+                    self.obj().remove_css_class(&css_class);
+                }
+            }
             // Emoji and color do never change
             if let Some(author) = author {
                 self.set_emoji(&author.emoji());


### PR DESCRIPTION
When the author of an avatar widget changes we need to remove the old background css class.