### PR TITLE
app: Allow join/new document buttons to shrik

### DIFF
--- a/reflection-app/src/landing_view/landing_view.blp
+++ b/reflection-app/src/landing_view/landing_view.blp
@@ -136,6 +136,7 @@ template $ReflectionLandingView: Adw.NavigationPage {
           icon-name: "add-document-symbolic";
           label: _("_New Document");
           use-underline: true;
+          can-shrink: true;
         };
 
         styles [
@@ -152,6 +153,7 @@ template $ReflectionLandingView: Adw.NavigationPage {
           icon-name: "join-document-symbolic";
           label: _("_Join Document");
           use-underline: true;
+	  can-shrink: true;
         };
 
         styles [


### PR DESCRIPTION
This makes reflection fully work on small screens, aka phones
<img width="913" height="1346" alt="Screenshot From 2026-01-28 18-20-49" src="https://github.com/user-attachments/assets/524d6a4f-1046-4078-9345-58f060bf26e4" />

This doesn't look awesome but better than stacking the buttons on small screens like this
<img width="913" height="1346" alt="Screenshot From 2026-01-28 18-18-04" src="https://github.com/user-attachments/assets/3ef85f56-3ed5-4967-bf71-148b83365ccf" />
